### PR TITLE
Fix: Added padding , margin , flex to make the content more clear.

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -26,7 +26,8 @@
   box-shadow: 0 4px 8px 0 rgba(0, 0, 0, 0.2);
   transition: 0.3s;
   width: 1000px;
-  margin: auto;
+  margin: 10px auto;
+  padding: 10px;
 }
 
 .group-image:hover {
@@ -41,4 +42,13 @@
 .group-count {
   font-size: 24px;
   cursor: pointer;
+}
+
+.group-content{
+  display: flex;
+ }
+
+.group-content .item{
+  padding: 10px;
+  border: 1px solid #eee;
 }

--- a/src/components/category.js
+++ b/src/components/category.js
@@ -20,7 +20,7 @@ class Category extends React.Component {
   render() {
     return (
       <div>
-        <div
+        <div className="item"
           onClick={() =>
             this.setState({
               hideCategoryItem: !this.state.hideCategoryItem


### PR DESCRIPTION
Added some CSS style to make the content more clear.
- Top/bottom margin added to the panel.
- Padding is added in the panel. The reason, when the item list open, the images were touching the bottom of the panel.
- Added a class `item` and added border, padding style to it. As well as making the group `flex`.

Thank you,
Neha